### PR TITLE
Add forced restart support to restartPhp command

### DIFF
--- a/lib/zendserver/README.md
+++ b/lib/zendserver/README.md
@@ -16,12 +16,19 @@ Example:
 <cacheClear component="${zendserver.cacheClear.datacache}"/>
 ```
 
-### tasksComplete ###
-Task to check if asynchronous tasks like ```cacheClear``` have completed.
+### restartPhp ###
+Restart the Zend Server instance or cluster either graceful or forced. The force parameter is optional.
 
-Poll every second example:
 ```
-<tasksComplete waitUnit="1" />
+<restartPhp force="true" />
+```
+
+### tasksComplete ###
+Task to check if asynchronous tasks like `cacheClear` have completed.
+
+Poll every second example and wait for maximum seconds. These are optional values, and the defaults are shown here.
+```
+<tasksComplete waitUnit="1" maxWait="30" />
 ```
 
 ## Configuration ##

--- a/lib/zendserver/src/RestartPhp.php
+++ b/lib/zendserver/src/RestartPhp.php
@@ -7,9 +7,27 @@ require_once 'WebApiTask.php';
  */
 class RestartPhp extends WebApiTask
 {
+    /**
+     * @var mixed
+     */
+    protected $force = null;
+
+    public function setForce($force)
+    {
+        $this->force = $force;
+    }
+
+    public function getForce()
+    {
+        return $this->force;
+    }
+
     public function main()
     {
         try {
+            if (null !== $this->getForce()) {
+                $this->setParams(array('force' => 'TRUE'));
+            }
             $this->executeApiTask('restartPhp');
             echo 'Server restarted';
         } catch(RuntimeException $e) {

--- a/lib/zendserver/src/TasksComplete.php
+++ b/lib/zendserver/src/TasksComplete.php
@@ -7,15 +7,35 @@ require_once 'WebApiTask.php';
  */
 class TasksComplete extends WebApiTask
 {
+    /**
+     * @var boolean
+     */
     private $tasksComplete = false;
 
+    /**
+     * @var integer
+     */
     private $waitUnit = 1;
 
+    /**
+     * @var integer
+     */
     private $maxWait = 30;
 
+    /**
+     * Set the interval to wait between checks
+     */
     public function setWaitUnit($waitUnit)
     {
         $this->waitUnit = intval($waitUnit);
+    }
+
+    /**
+     * Set the maximum waiting time
+     */
+    public function setMaxWait($maxWait)
+    {
+        $this->maxWait = $maxWait;
     }
 
     public function main()


### PR DESCRIPTION
By default the WebAPI tries to restart the server gracefully. Providing the force parameter forces a direct restart.
