### PR TITLE
Add sudo option to cron target

### DIFF
--- a/lib/cron/README.md
+++ b/lib/cron/README.md
@@ -38,6 +38,7 @@ Restart the cron program
 + `cron.files` - Location where the project cron files are
 + `cron.location` - Location on the server where the project cron files should be placed
 + `cron.program` - The cron program location
++ `cron.sudo` - Boolean. Run as sudo. (default false)
 
 #### Global configuration ####
 The cron targets use some global project properties to know which cron files should be copied/deleted.

--- a/lib/cron/cron.properties
+++ b/lib/cron/cron.properties
@@ -14,3 +14,6 @@ cron.location=/etc/cron.d/
 cron.program=/etc/init.d/crond
 # Debian / Ubuntu
 #cron.program=/etc/init.d/cron
+
+<!-- Sudo settings -->
+cron.sudo=false

--- a/lib/cron/cron.xml
+++ b/lib/cron/cron.xml
@@ -3,8 +3,19 @@
     <property file="${phing.dir.cron}/cron.properties" />
 
     <target name="cron-deploy">
-        <phingcall target="cron-delete-files" />
-        <phingcall target="cron-copy-files" />
+        <if>
+            <equals arg1="${cron.sudo}" arg2="true" />
+            <then>
+                <echo message="Running cron targets as sudo"/>
+                <phingcall target="cron-delete-files-sudo" />
+                <phingcall target="cron-copy-files-sudo" />
+            </then>
+            <else>
+                <echo message="Running cron targets as regular user"/>
+                <phingcall target="cron-delete-files" />
+                <phingcall target="cron-copy-files" />
+            </else>
+        </if>
     </target>
 
     <target name="cron-copy-files">
@@ -25,6 +36,14 @@
                 <include name="${project.app}-${project.environment}-*" />
             </fileset>
         </delete>
+    </target>
+
+    <target name="cron-copy-files-sudo">
+        <exec command="sudo cp ${cron.files}${project.app}-${project.environment}-* ${cron.location}" logoutput="true"/>
+    </target>
+
+    <target name="cron-delete-files-sudo">
+        <exec command="sudo rm ${cron.location}/${project.app}-${project.environment}-*" />
     </target>
 
     <target name="cron-start">


### PR DESCRIPTION
This cron task fails on some servers whereas the cron location is for root users only. Even reading the directory is impossible and thus the phing target fails;

```
[phingcall] No read access to /etc/cron.d
       [if] Error in IfTask
Execution of target "cron-deploy" failed for the following reason: Execution of the target buildfile failed. Aborting.
[phingcall] Execution of the target buildfile failed. Aborting.
```
