### PR TITLE
Feature/checkreturn

### DIFF
--- a/lib/composer/composer.properties
+++ b/lib/composer/composer.properties
@@ -3,3 +3,7 @@ composer.file=${project.basedir}/composer.phar
 
 <!-- Composer.lock file -->
 composer.lock=${project.basedir}/composer.lock
+
+<!-- Exec settings -->
+composer.checkreturn=false
+composer.passthru=true

--- a/lib/composer/composer.xml
+++ b/lib/composer/composer.xml
@@ -6,7 +6,7 @@
         <if>
             <not><available file="${composer.lock}" /></not>
             <then>
-                <exec passthru="${passthru}" executable="php">
+                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -16,7 +16,7 @@
                 </exec>
             </then>
             <else>
-                <exec passthru="${passthru}" executable="php">
+                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -32,7 +32,7 @@
         <if>
             <not><available file="${composer.lock}" /></not>
             <then>
-                <exec passthru="${passthru}" executable="php">
+                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -41,7 +41,7 @@
                 </exec>
             </then>
             <else>
-                <exec passthru="${passthru}" executable="php">
+                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -53,7 +53,7 @@
     </target>
 
     <target name="composer-update">
-        <exec passthru="${passthru}" executable="php">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
             <arg value="${composer.file}" />
             <arg value="-n" />
             <arg value="-q" />

--- a/lib/composer/composer.xml
+++ b/lib/composer/composer.xml
@@ -6,7 +6,7 @@
         <if>
             <not><available file="${composer.lock}" /></not>
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
+                <exec checkreturn="${composer.checkreturn}" passthru="${composer.passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -16,7 +16,7 @@
                 </exec>
             </then>
             <else>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
+                <exec checkreturn="${composer.checkreturn}" passthru="${composer.passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -32,7 +32,7 @@
         <if>
             <not><available file="${composer.lock}" /></not>
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
+                <exec checkreturn="${composer.checkreturn}" passthru="${composer.passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -41,7 +41,7 @@
                 </exec>
             </then>
             <else>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
+                <exec checkreturn="${composer.checkreturn}" passthru="${composer.passthru}" executable="php">
                     <arg value="${composer.file}" />
                     <arg value="-n" />
                     <arg value="-q" />
@@ -53,7 +53,7 @@
     </target>
 
     <target name="composer-update">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="php">
+        <exec checkreturn="${composer.checkreturn}" passthru="${composer.passthru}" executable="php">
             <arg value="${composer.file}" />
             <arg value="-n" />
             <arg value="-q" />

--- a/lib/cron/cron.properties
+++ b/lib/cron/cron.properties
@@ -17,3 +17,7 @@ cron.program=/etc/init.d/crond
 
 <!-- Sudo settings -->
 cron.sudo=false
+
+<!-- Exec settings -->
+cron.checkreturn=false
+cron.passthru=true

--- a/lib/cron/cron.xml
+++ b/lib/cron/cron.xml
@@ -52,23 +52,23 @@
             </filterchain>
         </reflexive>
         <exec command="sudo cp ${cron.files}${project.app}-${project.environment}-* ${cron.location}" logoutput="true"
-              checkreturn="${checkreturn}" />
+              checkreturn="${cron.checkreturn}" />
     </target>
 
     <target name="cron-delete-files-sudo">
-        <exec checkreturn="${checkreturn}" command="sudo rm ${cron.location}/${project.app}-${project.environment}-*" />
+        <exec checkreturn="${cron.checkreturn}" command="sudo rm ${cron.location}/${project.app}-${project.environment}-*" />
     </target>
 
     <target name="cron-start">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${cron.program} start" />
+        <exec checkreturn="${cron.checkreturn}" passthru="${cron.passthru}" command="${cron.program} start" />
     </target>
 
     <target name="cron-stop">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${cron.program} stop" />
+        <exec checkreturn="${cron.checkreturn}" passthru="${cron.passthru}" command="${cron.program} stop" />
     </target>
 
     <target name="cron-restart">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${cron.program} restart" />
+        <exec checkreturn="${cron.checkreturn}" passthru="${cron.passthru}" command="${cron.program} restart" />
     </target>
 
 </project>

--- a/lib/cron/cron.xml
+++ b/lib/cron/cron.xml
@@ -51,23 +51,24 @@
                 <expandproperties/>
             </filterchain>
         </reflexive>
-        <exec command="sudo cp ${cron.files}${project.app}-${project.environment}-* ${cron.location}" logoutput="true"/>
+        <exec command="sudo cp ${cron.files}${project.app}-${project.environment}-* ${cron.location}" logoutput="true"
+              checkreturn="${checkreturn}" />
     </target>
 
     <target name="cron-delete-files-sudo">
-        <exec command="sudo rm ${cron.location}/${project.app}-${project.environment}-*" />
+        <exec checkreturn="${checkreturn}" command="sudo rm ${cron.location}/${project.app}-${project.environment}-*" />
     </target>
 
     <target name="cron-start">
-        <exec passthru="${passthru}" command="${cron.program} start" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${cron.program} start" />
     </target>
 
     <target name="cron-stop">
-        <exec passthru="${passthru}" command="${cron.program} stop" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${cron.program} stop" />
     </target>
 
     <target name="cron-restart">
-        <exec passthru="${passthru}" command="${cron.program} restart" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${cron.program} restart" />
     </target>
 
 </project>

--- a/lib/csslint/csslint.properties
+++ b/lib/csslint/csslint.properties
@@ -6,3 +6,7 @@ csslint.format=junit-xml
 csslint.results.file=${project.root}/build/frontend/csslint-junit.xml
 
 csslint.source=${frontend.root}/public/css
+
+<!-- Exec settings -->
+csslint.checkreturn=false
+csslint.passthru=true

--- a/lib/csslint/csslint.xml
+++ b/lib/csslint/csslint.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.csslint}/csslint.properties" />
 
     <target name="csslint">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="java -jar
+        <exec checkreturn="${csslint.checkreturn}" passthru="${csslint.passthru}" command="java -jar
             ${rhino.jar}
             ${csslint.file}
             --format=${csslint.format}
@@ -12,7 +12,7 @@
     </target>
 
     <target name="csslint-tty">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" outputProperty="csslint.output" executable="java">
+        <exec checkreturn="${csslint.checkreturn}" passthru="${csslint.passthru}" outputProperty="csslint.output" executable="java">
             <arg line="-jar" />
             <arg line="${rhino.jar}" />
             <arg line="${csslint.file}" />

--- a/lib/csslint/csslint.xml
+++ b/lib/csslint/csslint.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.csslint}/csslint.properties" />
 
     <target name="csslint">
-        <exec passthru="${passthru}" command="java -jar
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="java -jar
             ${rhino.jar}
             ${csslint.file}
             --format=${csslint.format}
@@ -12,7 +12,7 @@
     </target>
 
     <target name="csslint-tty">
-        <exec passthru="${passthru}" outputProperty="csslint.output" executable="java">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" outputProperty="csslint.output" executable="java">
             <arg line="-jar" />
             <arg line="${rhino.jar}" />
             <arg line="${csslint.file}" />

--- a/lib/dbdeploy/dbdeploy.properties
+++ b/lib/dbdeploy/dbdeploy.properties
@@ -19,3 +19,7 @@ database.deltas.undo=${project.basedir}/data/sql/dbdeploy_undo.sql
 database.dbdeploy.changelog=${phing.dir.dbdeploy}/data/dbdeploy.sql
 
 dbdeploy.checkall=true
+
+<!-- Exec settings -->
+database.checkreturn=false
+database.passthru=true

--- a/lib/dbdeploy/dbdeploy.xml
+++ b/lib/dbdeploy/dbdeploy.xml
@@ -10,12 +10,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${database.checkreturn}" passthru="${database.passthru}"
                     command="mysqldump -u${database.user} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} ${database.name}">
                 </exec>
             </then>
             <else>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${database.checkreturn}" passthru="${database.passthru}"
                     command="mysqldump -u${database.user} -p${database.password} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} -p${database.password} ${database.name}">
                 </exec>
             </else>

--- a/lib/dbdeploy/dbdeploy.xml
+++ b/lib/dbdeploy/dbdeploy.xml
@@ -10,12 +10,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="mysqldump -u${database.user} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} ${database.name}">
                 </exec>
             </then>
             <else>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="mysqldump -u${database.user} -p${database.password} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} -p${database.password} ${database.name}">
                 </exec>
             </else>

--- a/lib/doctrine/doctrine.properties
+++ b/lib/doctrine/doctrine.properties
@@ -1,3 +1,7 @@
 doctrine.cli=APPLICATION_ENV=development php ${project.basedir}/tools/doctrine.php
 doctrine.cli.config.dir=${project.basedir}
 doctrine.orm.proxy.dir=${project.basedir}/data/Doctrine/Proxies
+
+<!-- Exec settings -->
+doctrine.checkreturn=false
+doctrine.passthru=true

--- a/lib/doctrine/doctrine.xml
+++ b/lib/doctrine/doctrine.xml
@@ -4,11 +4,11 @@
 
     <target name="doctrine-generate-proxies"  description="Generate the doctrine proxy files">
         <mkdir dir="${doctrine.orm.proxy.dir}" />
-        <exec passthru="${passthru}" command="${doctrine.cli} orm:generate-proxies" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${doctrine.cli} orm:generate-proxies" />
     </target>
 
     <target name="doctrine-schema-update">
-        <exec passthru="${passthru}" executable="${doctrine.cli}" dir="${doctrine.cli.config.dir}">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${doctrine.cli}" dir="${doctrine.cli.config.dir}">
             <arg value="orm:schema-tool:update" />
             <arg value="--force" />
         </exec>

--- a/lib/doctrine/doctrine.xml
+++ b/lib/doctrine/doctrine.xml
@@ -4,11 +4,11 @@
 
     <target name="doctrine-generate-proxies"  description="Generate the doctrine proxy files">
         <mkdir dir="${doctrine.orm.proxy.dir}" />
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${doctrine.cli} orm:generate-proxies" />
+        <exec checkreturn="${doctrine.checkreturn}" passthru="${doctrine.passthru}" command="${doctrine.cli} orm:generate-proxies" />
     </target>
 
     <target name="doctrine-schema-update">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${doctrine.cli}" dir="${doctrine.cli.config.dir}">
+        <exec checkreturn="${doctrine.checkreturn}" passthru="${doctrine.passthru}" executable="${doctrine.cli}" dir="${doctrine.cli.config.dir}">
             <arg value="orm:schema-tool:update" />
             <arg value="--force" />
         </exec>

--- a/lib/java/java.properties
+++ b/lib/java/java.properties
@@ -1,0 +1,3 @@
+<!-- Exec settings -->
+java.checkreturn=true
+java.passthru=true

--- a/lib/java/java.xml
+++ b/lib/java/java.xml
@@ -5,7 +5,7 @@
     <target name="java-check">
         <trycatch property="java.placeholder">
             <try>
-                <exec passthru="${passthru}" checkreturn="true" outputProperty="java.version" command="java -version" />
+                <exec passthru="${java.passthru}" checkreturn="${java.checkreturn}" outputProperty="java.version" command="java -version" />
                 <property name="java.available" value="true" />
             </try>
             <catch>

--- a/lib/jslint/jslint.properties
+++ b/lib/jslint/jslint.properties
@@ -5,3 +5,7 @@ jslint.options=--browser --white
 jslint.results.file=${project.root}/jslint.xml
 
 jslint.source=frontend/public/js/**/*.js frontend/public/js/*.js
+
+<!-- Exec settings -->
+jslint.checkreturn=false
+jslint.passthru=true

--- a/lib/jslint/jslint.xml
+++ b/lib/jslint/jslint.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.jslint}/jslint.properties" />
 
     <target name="jslint">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}"  dir="${jslint.exec.dir}" command="java -jar ${jslint.jar}
+        <exec checkreturn="${jslint.checkreturn}" passthru="${jslint.passthru}"  dir="${jslint.exec.dir}" command="java -jar ${jslint.jar}
             --report ${jslint.format}
             ${jslint.options}
             ${jslint.source}
@@ -12,7 +12,7 @@
     </target>
 
     <target name="jslint-tty">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" dir="${jslint.exec.dir}" outputProperty="jslint.output" command="java -jar ${jslint.jar}
+        <exec checkreturn="${jslint.checkreturn}" passthru="${jslint.passthru}" dir="${jslint.exec.dir}" outputProperty="jslint.output" command="java -jar ${jslint.jar}
             ${jslint.options}
             ${jslint.source}
         " />

--- a/lib/jslint/jslint.xml
+++ b/lib/jslint/jslint.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.jslint}/jslint.properties" />
 
     <target name="jslint">
-        <exec passthru="${passthru}"  dir="${jslint.exec.dir}" command="java -jar ${jslint.jar}
+        <exec checkreturn="${checkreturn}" passthru="${passthru}"  dir="${jslint.exec.dir}" command="java -jar ${jslint.jar}
             --report ${jslint.format}
             ${jslint.options}
             ${jslint.source}
@@ -12,7 +12,7 @@
     </target>
 
     <target name="jslint-tty">
-        <exec passthru="${passthru}" dir="${jslint.exec.dir}" outputProperty="jslint.output" command="java -jar ${jslint.jar}
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" dir="${jslint.exec.dir}" outputProperty="jslint.output" command="java -jar ${jslint.jar}
             ${jslint.options}
             ${jslint.source}
         " />

--- a/lib/memcached/memcached.properties
+++ b/lib/memcached/memcached.properties
@@ -1,0 +1,3 @@
+<!-- Exec settings -->
+memcached.checkreturn=false
+memcached.passthru=true

--- a/lib/memcached/memcached.xml
+++ b/lib/memcached/memcached.xml
@@ -2,15 +2,15 @@
 <project name="memcached" basedir=".">
 
     <target name="memcached-start" description="start memcached">
-        <exec passthru="${passthru}" command="service memcached start" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="service memcached start" />
     </target>
 
     <target name="memcached-stop" description="stop memcached">
-        <exec passthru="${passthru}" command="service memcached stop" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="service memcached stop" />
     </target>
 
     <target name="memcached-restart" description="restart memcached">
-        <exec passthru="${passthru}" command="service memcached restart" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="service memcached restart" />
     </target>
 
 </project>

--- a/lib/memcached/memcached.xml
+++ b/lib/memcached/memcached.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project name="memcached" basedir=".">
+    <property file="${phing.dir.memcached}/memcached.properties" />
 
     <target name="memcached-start" description="start memcached">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="service memcached start" />
+        <exec checkreturn="${memcached.checkreturn}" passthru="${memcached.passthru}" command="service memcached start" />
     </target>
 
     <target name="memcached-stop" description="stop memcached">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="service memcached stop" />
+        <exec checkreturn="${memcached.checkreturn}" passthru="${memcached.passthru}" command="service memcached stop" />
     </target>
 
     <target name="memcached-restart" description="restart memcached">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="service memcached restart" />
+        <exec checkreturn="${memcached.checkreturn}" passthru="${memcached.passthru}" command="service memcached restart" />
     </target>
 
 </project>

--- a/lib/mysql/mysql.properties
+++ b/lib/mysql/mysql.properties
@@ -6,3 +6,7 @@ database.port=3306
 
 mysql.dump.file=~/mysqldump.${project.environment}.sql
 mysql.dump.gzip=true
+
+<!-- Exec settings -->
+mysql.checkreturn=false
+mysql.passthru=true

--- a/lib/mysql/mysql.xml
+++ b/lib/mysql/mysql.xml
@@ -6,17 +6,17 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec passthru="${passthru}" command="mysqldump -u${database.user} -h${database.host} --opt ${database.name} -P${database.port} > ${mysql.dump.file}" />
+                <exec checkreturn="${checkreturn}" passthru="${passthru}" command="mysqldump -u${database.user} -h${database.host} --opt ${database.name} -P${database.port} > ${mysql.dump.file}" />
             </then>
             <else>
-                <exec passthru="${passthru}" command="mysqldump -u${database.user} -p'${database.password}' -h${database.host} -P${database.port} --opt ${database.name} > ${mysql.dump.file}" />
+                <exec checkreturn="${checkreturn}" passthru="${passthru}" command="mysqldump -u${database.user} -p'${database.password}' -h${database.host} -P${database.port} --opt ${database.name} > ${mysql.dump.file}" />
             </else>
         </if>
 
         <if>
             <equals arg1="${mysql.dump.gzip}" arg2="true" />
             <then>
-                <exec passthru="${passthru}" command="gzip ${mysql.dump.file}" />
+                <exec checkreturn="${checkreturn}" passthru="${passthru}" command="gzip ${mysql.dump.file}" />
             </then>
         </if>
     </target>
@@ -25,12 +25,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="mysql -u${database.user} -e 'SET FOREIGN_KEY_CHECKS = 0; DROP DATABASE ${database.name}; SET FOREIGN_KEY_CHECKS = 1;'">
                 </exec>
             </then>
             <else>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="mysql -u${database.user} -p'${database.password}' -e 'SET FOREIGN_KEY_CHECKS = 0; DROP DATABASE ${database.name}; SET FOREIGN_KEY_CHECKS = 1;'">
                 </exec>
             </else>
@@ -41,12 +41,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="mysqldump -u${database.user} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} ${database.name}">
                 </exec>
             </then>
             <else>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="mysqldump -u${database.user} -p${database.password} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} -p${database.password} ${database.name}">
                 </exec>
             </else>

--- a/lib/mysql/mysql.xml
+++ b/lib/mysql/mysql.xml
@@ -6,17 +6,17 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}" command="mysqldump -u${database.user} -h${database.host} --opt ${database.name} -P${database.port} > ${mysql.dump.file}" />
+                <exec checkreturn="${mysql.checkreturn}" passthru="${mysql.passthru}" command="mysqldump -u${database.user} -h${database.host} --opt ${database.name} -P${database.port} > ${mysql.dump.file}" />
             </then>
             <else>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}" command="mysqldump -u${database.user} -p'${database.password}' -h${database.host} -P${database.port} --opt ${database.name} > ${mysql.dump.file}" />
+                <exec checkreturn="${mysql.checkreturn}" passthru="${mysql.passthru}" command="mysqldump -u${database.user} -p'${database.password}' -h${database.host} -P${database.port} --opt ${database.name} > ${mysql.dump.file}" />
             </else>
         </if>
 
         <if>
             <equals arg1="${mysql.dump.gzip}" arg2="true" />
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}" command="gzip ${mysql.dump.file}" />
+                <exec checkreturn="${mysql.checkreturn}" passthru="${mysql.passthru}" command="gzip ${mysql.dump.file}" />
             </then>
         </if>
     </target>
@@ -25,12 +25,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${mysql.checkreturn}" passthru="${mysql.passthru}"
                     command="mysql -u${database.user} -e 'SET FOREIGN_KEY_CHECKS = 0; DROP DATABASE ${database.name}; SET FOREIGN_KEY_CHECKS = 1;'">
                 </exec>
             </then>
             <else>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${mysql.checkreturn}" passthru="${mysql.passthru}"
                     command="mysql -u${database.user} -p'${database.password}' -e 'SET FOREIGN_KEY_CHECKS = 0; DROP DATABASE ${database.name}; SET FOREIGN_KEY_CHECKS = 1;'">
                 </exec>
             </else>
@@ -41,12 +41,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${mysql.checkreturn}" passthru="${mysql.passthru}"
                     command="mysqldump -u${database.user} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} ${database.name}">
                 </exec>
             </then>
             <else>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${mysql.checkreturn}" passthru="${mysql.passthru}"
                     command="mysqldump -u${database.user} -p${database.password} --add-drop-table --no-data ${database.name} | grep '^DROP\|^\/\*\!' | mysql -u${database.user} -p${database.password} ${database.name}">
                 </exec>
             </else>

--- a/lib/patchdb/patchdb.properties
+++ b/lib/patchdb/patchdb.properties
@@ -4,3 +4,7 @@ database.name=
 
 patchdb.file=${project.basedir}/dev/patchdb/patchdb
 patchdb.patches=${project.basedir}/api/data/database
+
+<!-- Exec settings -->
+patchdb.checkreturn=false
+patchdb.passthru=true

--- a/lib/patchdb/patchdb.xml
+++ b/lib/patchdb/patchdb.xml
@@ -8,12 +8,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${patchdb.checkreturn}" passthru="${patchdb.passthru}"
                     command="${patchdb.file} -C -d ${database.name} -u ${database.user} -P ${patchdb.patches}">
                 </exec>
             </then>
             <else>
-                <exec checkreturn="${checkreturn}" passthru="${passthru}"
+                <exec checkreturn="${patchdb.checkreturn}" passthru="${patchdb.passthru}"
                     command="${patchdb.file} -C -d ${database.name} -u ${database.user} -p${database.password} -P ${patchdb.patches}">
                 </exec>
             </else>

--- a/lib/patchdb/patchdb.xml
+++ b/lib/patchdb/patchdb.xml
@@ -8,12 +8,12 @@
         <if>
             <equals arg1="${database.password}" arg2="" />
             <then>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="${patchdb.file} -C -d ${database.name} -u ${database.user} -P ${patchdb.patches}">
                 </exec>
             </then>
             <else>
-                <exec passthru="${passthru}"
+                <exec checkreturn="${checkreturn}" passthru="${passthru}"
                     command="${patchdb.file} -C -d ${database.name} -u ${database.user} -p${database.password} -P ${patchdb.patches}">
                 </exec>
             </else>

--- a/lib/pdepend/pdepend.properties
+++ b/lib/pdepend/pdepend.properties
@@ -4,3 +4,7 @@ pdepend.chart.file=
 pdepend.pyramid.file=
 
 pdepend.source=
+
+<!-- Exec settings -->
+pdepend.checkreturn=false
+pdepend.passthru=true

--- a/lib/pdepend/pdepend.xml
+++ b/lib/pdepend/pdepend.xml
@@ -4,7 +4,7 @@
 
      <target name="pdepend"
         description="Generate jdepend.xml and software metrics charts using PHP_Depend">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${pdepend.file}">
+        <exec checkreturn="${pdepend.checkreturn}" passthru="${pdepend.passthru}" executable="${pdepend.file}">
             <arg value="--jdepend-xml=${pdepend.xml.file}" />
             <arg value="--jdepend-chart=${pdepend.chart.file}" />
             <arg value="--overview-pyramid=${pdepend.pyramid.file}" />

--- a/lib/pdepend/pdepend.xml
+++ b/lib/pdepend/pdepend.xml
@@ -4,7 +4,7 @@
 
      <target name="pdepend"
         description="Generate jdepend.xml and software metrics charts using PHP_Depend">
-        <exec passthru="${passthru}" executable="${pdepend.file}">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${pdepend.file}">
             <arg value="--jdepend-xml=${pdepend.xml.file}" />
             <arg value="--jdepend-chart=${pdepend.chart.file}" />
             <arg value="--overview-pyramid=${pdepend.pyramid.file}" />

--- a/lib/phpcs/phpcs.properties
+++ b/lib/phpcs/phpcs.properties
@@ -5,3 +5,7 @@ phpcs.checkstyle.file=
 phpcs.exclude.path=
 phpcs.include.path=${project.basedir}
 phpcs.extensions=php
+
+<!-- Exec settings -->
+phpcs.checkreturn=false
+phpcs.passthru=true

--- a/lib/phpcs/phpcs.xml
+++ b/lib/phpcs/phpcs.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.phpcs}/phpcs.properties" />
 
    <target name="phpcs" description="Generate checkstyle.xml using PHP_CodeSniffer">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${phpcs.file}
+        <exec checkreturn="${phpcs.checkreturn}" passthru="${phpcs.passthru}" command="${phpcs.file}
             --extensions=${phpcs.extensions}
             --standard=${phpcs.standards.file}
             --ignore='${phpcs.exclude.path}'
@@ -14,7 +14,7 @@
     </target>
 
     <target name="phpcs-tty" description="human readable report for PHP CodeSniffer Standards Check">
-        <exec checkreturn="${checkreturn}" outputProperty="standards-check.output" escape="false" command="${phpcs.file}
+        <exec checkreturn="${phpcs.checkreturn}" outputProperty="standards-check.output" escape="false" command="${phpcs.file}
             --standard=${phpcs.standards.file}
             --extensions=${phpcs.extensions}
             --ignore=${phpcs.exclude.path}

--- a/lib/phpcs/phpcs.xml
+++ b/lib/phpcs/phpcs.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.phpcs}/phpcs.properties" />
 
    <target name="phpcs" description="Generate checkstyle.xml using PHP_CodeSniffer">
-        <exec passthru="${passthru}" command="${phpcs.file}
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="${phpcs.file}
             --extensions=${phpcs.extensions}
             --standard=${phpcs.standards.file}
             --ignore='${phpcs.exclude.path}'
@@ -14,7 +14,7 @@
     </target>
 
     <target name="phpcs-tty" description="human readable report for PHP CodeSniffer Standards Check">
-        <exec outputProperty="standards-check.output" escape="false" command="${phpcs.file}
+        <exec checkreturn="${checkreturn}" outputProperty="standards-check.output" escape="false" command="${phpcs.file}
             --standard=${phpcs.standards.file}
             --extensions=${phpcs.extensions}
             --ignore=${phpcs.exclude.path}

--- a/lib/phpmd/phpmd.properties
+++ b/lib/phpmd/phpmd.properties
@@ -2,3 +2,7 @@ phpmd.file=${project.basedir}/vendor/bin/phpmd
 phpmd.config=${phing.dir.phpmd}/data/phpmd-ruleset.xml
 phpmd.log.file=
 phpmd.exclude=
+
+<!-- Exec settings -->
+phpmd.checkreturn=false
+phpmd.passthru=true

--- a/lib/phpmd/phpmd.xml
+++ b/lib/phpmd/phpmd.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.phpmd}/phpmd.properties" />
 
     <target name="phpmd" description="Generate pmd.xml using PHPMD">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${phpmd.file}">
+        <exec checkreturn="${phpmd.checkreturn}" passthru="${phpmd.passthru}" executable="${phpmd.file}">
             <arg path="${project.basedir}" />
             <arg value="xml" />
             <arg value="${phpmd.config}" />

--- a/lib/phpmd/phpmd.xml
+++ b/lib/phpmd/phpmd.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.phpmd}/phpmd.properties" />
 
     <target name="phpmd" description="Generate pmd.xml using PHPMD">
-        <exec passthru="${passthru}" executable="${phpmd.file}">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${phpmd.file}">
             <arg path="${project.basedir}" />
             <arg value="xml" />
             <arg value="${phpmd.config}" />

--- a/lib/phpunit/phpunit.properties
+++ b/lib/phpunit/phpunit.properties
@@ -1,2 +1,6 @@
 phpunit.file=${project.basedir}/vendor/bin/phpunit
 phpunit.config=
+
+<!-- Exec settings -->
+phpunit.checkreturn=false
+phpunit.passthru=true

--- a/lib/phpunit/phpunit.xml
+++ b/lib/phpunit/phpunit.xml
@@ -4,7 +4,7 @@
 
     <target name="phpunit"
         description="Run unit tests using PHPUnit">
-        <exec passthru="${passthru}" executable="${phpunit.file}">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${phpunit.file}" checkreturn="${checkreturn}">
             <arg value="-c" />
             <arg path="${phpunit.config}" />
         </exec>

--- a/lib/phpunit/phpunit.xml
+++ b/lib/phpunit/phpunit.xml
@@ -4,7 +4,7 @@
 
     <target name="phpunit"
         description="Run unit tests using PHPUnit">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${phpunit.file}" checkreturn="${checkreturn}">
+        <exec checkreturn="${phpunit.checkreturn}" passthru="${phpunit.passthru}" executable="${phpunit.file}">
             <arg value="-c" />
             <arg path="${phpunit.config}" />
         </exec>

--- a/lib/solr/solr.properties
+++ b/lib/solr/solr.properties
@@ -5,3 +5,7 @@ solr.config.destination=${phing.dir}
 
 solr.core.source=autophing-core
 solr.core.name=${solr.core.source}
+
+<!-- Exec settings -->
+solr.checkreturn=false
+solr.passthru=true

--- a/lib/solr/solr.xml
+++ b/lib/solr/solr.xml
@@ -42,7 +42,7 @@
     </target>
 
     <target name="solr-api-core-create">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="curl" escape="true">
+        <exec checkreturn="${solr.checkreturn}" passthru="${solr.passthru}" executable="curl" escape="true">
             <arg line="-X" />
             <arg value="GET" />
             <arg value="${solr.http.url}admin/cores?action=CREATE&amp;name=${solr.core.name}&amp;instanceDir=${solr.core.name}&amp;persist=true" />
@@ -50,7 +50,7 @@
     </target>
 
     <target name="solr-api-core-reload">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="curl" escape="true">
+        <exec checkreturn="${solr.checkreturn}" passthru="${solr.passthru}" executable="curl" escape="true">
             <arg line="-X" />
             <arg value="GET" />
             <arg value="${solr.http.url}admin/cores?action=RELOAD&amp;core=${solr.core.name}" />
@@ -58,7 +58,7 @@
     </target>
     
     <target name="solr-api-core-unload">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="curl" escape="true">
+        <exec checkreturn="${solr.checkreturn}" passthru="${solr.passthru}" executable="curl" escape="true">
             <arg line="-X" />
             <arg value="GET" />
             <arg value="${solr.http.url}admin/cores?action=UNLOAD&amp;core=${solr.core.name}" />

--- a/lib/solr/solr.xml
+++ b/lib/solr/solr.xml
@@ -42,7 +42,7 @@
     </target>
 
     <target name="solr-api-core-create">
-        <exec passthru="${passthru}" executable="curl" escape="true">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="curl" escape="true">
             <arg line="-X" />
             <arg value="GET" />
             <arg value="${solr.http.url}admin/cores?action=CREATE&amp;name=${solr.core.name}&amp;instanceDir=${solr.core.name}&amp;persist=true" />
@@ -50,7 +50,7 @@
     </target>
 
     <target name="solr-api-core-reload">
-        <exec passthru="${passthru}" executable="curl" escape="true">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="curl" escape="true">
             <arg line="-X" />
             <arg value="GET" />
             <arg value="${solr.http.url}admin/cores?action=RELOAD&amp;core=${solr.core.name}" />
@@ -58,7 +58,7 @@
     </target>
     
     <target name="solr-api-core-unload">
-        <exec passthru="${passthru}" executable="curl" escape="true">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="curl" escape="true">
             <arg line="-X" />
             <arg value="GET" />
             <arg value="${solr.http.url}admin/cores?action=UNLOAD&amp;core=${solr.core.name}" />

--- a/lib/swagger/swagger.properties
+++ b/lib/swagger/swagger.properties
@@ -6,3 +6,7 @@ swagger.api.url=
 swagger.api.version=dev
 
 swagger.docs.output=${project.basedir}/api-docs
+
+<!-- Exec settings -->
+swagger.checkreturn=false
+swagger.passthru=true

--- a/lib/swagger/swagger.xml
+++ b/lib/swagger/swagger.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.swagger}/swagger.properties" />
 
     <target name="swagger-generate-docs">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${swagger.file}">
+        <exec checkreturn="${swagger.checkreturn}" passthru="${swagger.passthru}" executable="${swagger.file}">
             <arg value="${swagger.api.source}" />
             <arg line="-o ${swagger.docs.output}" />
             <arg line="--default-base-path ${swagger.api.url}" />

--- a/lib/swagger/swagger.xml
+++ b/lib/swagger/swagger.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.swagger}/swagger.properties" />
 
     <target name="swagger-generate-docs">
-        <exec passthru="${passthru}" executable="${swagger.file}">
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" executable="${swagger.file}">
             <arg value="${swagger.api.source}" />
             <arg line="-o ${swagger.docs.output}" />
             <arg line="--default-base-path ${swagger.api.url}" />

--- a/lib/yuicompressor/yuicompressor.properties
+++ b/lib/yuicompressor/yuicompressor.properties
@@ -2,3 +2,7 @@ yuicompressor.jar=${project.basedir}/vendor/yui/yuicompressor/build/yuicompresso
 yuicompressor.options=
 yuicompressor.outputfile=.css$:-min.css
 yuicompressor.inputfile=*.css
+
+<!-- Exec settings -->
+yuicompressor.checkreturn=false
+yuicompressor.passthru=true

--- a/lib/yuicompressor/yuicompressor.xml
+++ b/lib/yuicompressor/yuicompressor.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.yuicompressor}/yuicompressor.properties" />
 
     <target name="yuicompressor">
-        <exec passthru="${passthru}" command="java -jar
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="java -jar
             ${yuicompressor.jar}
             ${yuicompressor.options}
             -o ${yuicompressor.outputfile}

--- a/lib/yuicompressor/yuicompressor.xml
+++ b/lib/yuicompressor/yuicompressor.xml
@@ -3,7 +3,7 @@
     <property file="${phing.dir.yuicompressor}/yuicompressor.properties" />
 
     <target name="yuicompressor">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="java -jar
+        <exec checkreturn="${yuicompressor.checkreturn}" passthru="${yuicompressor.passthru}" command="java -jar
             ${yuicompressor.jar}
             ${yuicompressor.options}
             -o ${yuicompressor.outputfile}

--- a/lib/zf2/zf2.properties
+++ b/lib/zf2/zf2.properties
@@ -9,3 +9,7 @@ zf2.config.file=${project.basedir}/config/autoload/local.php
 
 <!-- ZF2 local.php.dist file -->
 zf2.config.template=${project.basedir}/config/autoload/local.php.dist
+
+<!-- Exec settings -->
+zf2.checkreturn=false
+zf2.passthru=true

--- a/lib/zf2/zf2.xml
+++ b/lib/zf2/zf2.xml
@@ -11,7 +11,7 @@
     </target>
 
     <target name="zf2-console-command">
-        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="php ${zf2.application.file} ${zf2.console.command}" />
+        <exec checkreturn="${zf2.checkreturn}" passthru="${zf2.passthru}" command="php ${zf2.application.file} ${zf2.console.command}" />
     </target>
 
 </project>

--- a/lib/zf2/zf2.xml
+++ b/lib/zf2/zf2.xml
@@ -11,7 +11,7 @@
     </target>
 
     <target name="zf2-console-command">
-        <exec passthru="${passthru}" command="php ${zf2.application.file} ${zf2.console.command}" />
+        <exec checkreturn="${checkreturn}" passthru="${passthru}" command="php ${zf2.application.file} ${zf2.console.command}" />
     </target>
 
 </project>


### PR DESCRIPTION
Hey Nick,

We've recently switched to Travis for our Continuous Integration needs. As you might know, Travis checks the return value of the executed build scripts to determine if the build has succeeded or failed. 
So I've taken the liberty to introduce a `checkreturn` in each exec statement of the autophing libraries. 

In addition, the passthru and checkreturn properties can be configured on a library basis (instead of a global passthru). 
## Things you should know:

– I've only tested this in my local phpunit / phpcs setup on a recent project. So I'm not sure if this actually works for tools like phplint or swagger.
– Merging this **WILL BREAK** backward compatibility. So ensure to bump the major version when releasing a merged PR.
– `$library$.passthru` has now a default value of `true` to ensure maximum backward compatibility
– `$library$.checkreturn` has now a default value of `false` to ensure maximum backward compatibility

p.s. @eXistenZNL could you give your opinion / review on this PR?
